### PR TITLE
Partially update to parse5@2

### DIFF
--- a/dom5.js
+++ b/dom5.js
@@ -537,18 +537,15 @@ function append(parent, newNode) {
 
 var parse5 = require('parse5');
 function parse(text, options) {
-  var parser = new parse5.Parser(parse5.TreeAdapters.default, options);
-  return parser.parse(text);
+  return parse5.parse(text, options);
 }
 
 function parseFragment(text) {
-  var parser = new parse5.Parser();
-  return parser.parseFragment(text);
+  return parse5.parseFragment(text);
 }
 
 function serialize(ast) {
-  var serializer = new parse5.Serializer();
-  return serializer.serialize(ast);
+  return parse5.serialize(ast);
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   "homepage": "https://github.com/PolymerLabs/dom5",
   "dependencies": {
     "clone": "^1.0.2",
-    "parse5": "^1.4.1"
+    "parse5": "^2.0.0"
   }
 }

--- a/test/dom5_test.js
+++ b/test/dom5_test.js
@@ -21,33 +21,30 @@ suite('dom5', function() {
     var parse5 = require('parse5');
     var docText = "<!DOCTYPE html><div id='A' qux>a1<div bar='b1' bar='b2'>b1</div>a2</div><!-- comment -->";
     var fragText = '<template><span>Foo</span></template><!-- comment --><my-bar></my-bar>';
-    var parser = new parse5.Parser();
 
     test('parse', function() {
-      var doc_expected = parser.parse(docText);
+      var doc_expected = parse5.parse(docText);
       var doc_actual = dom5.parse(docText);
 
       assert.deepEqual(doc_expected, doc_actual);
     });
 
     test('parseFragment', function() {
-      var frag_expected = parser.parseFragment(fragText);
+      var frag_expected = parse5.parseFragment(fragText);
       var frag_actual = dom5.parseFragment(fragText);
 
       assert.deepEqual(frag_expected, frag_actual);
     });
 
     test('serialize', function() {
-      var serializer = new parse5.Serializer();
-
-      var ast = parser.parse(docText);
-      var expected = serializer.serialize(ast);
+      var ast = parse5.parse(docText);
+      var expected = parse5.serialize(ast);
       var actual = dom5.serialize(ast);
 
       assert.equal(expected, actual);
 
-      ast = parser.parseFragment(fragText);
-      expected = serializer.serialize(ast);
+      ast = parse5.parseFragment(fragText);
+      expected = parse5.serialize(ast);
       actual = dom5.serialize(ast);
 
       assert.equal(expected, actual);


### PR DESCRIPTION
**This PR is not ready to merge, there are failing tests.**

I've updated to to `parse5@2` and made most of the changes required, but there has been a change to the interface for `<template>` nodes and I'm not sure how dom5 wants to handle it. See the commit message for details.

I also recommend removing `dom5.{parse,parseFragment,serialize}` since they are now the same functions that `parse5` provides directly. This would also enable having `parse5` as only a dev dependency.