### PR TITLE
@types/parse5@v0.0.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@types/clone": "^0.1.29",
     "@types/node": "^4.0.30",
-    "@types/parse5": "0.0.28",
+    "@types/parse5": "^0.0.31",
     "clone": "^1.0.2",
     "parse5": "^1.4.1"
   }


### PR DESCRIPTION
`@types/parse5@v0.0.28` is broken in npm. It results in a weird headers error when installed that npm marks as INVALID and that kpm fails on entirely.

- Confirmed that `npm run build` still builds properly with the latest version (we still define the actual module interface in `custom_typings/`).
- Confirmed with @rictic that there was no specific reason that he could remember that @types/parse5 was pinned directly to 0.0.28.

/cc @rictic @usergenic 