### PR TITLE
Added nodeWalkAncestors

### DIFF
--- a/dom5.ts
+++ b/dom5.ts
@@ -403,6 +403,17 @@ export function nodeWalkPrior(node: Node, predicate: Predicate): Node|
   return undefined;
 }
 
+export function nodeWalkParent(node: Node, predicate: Predicate): Node|undefined {
+  const parent = node.parentNode;
+  if (!parent) {
+    return undefined;
+  }
+  if (predicate(parent)) {
+    return parent;
+  }
+  return nodeWalkParent(parent, predicate);
+}
+
 /**
  * Equivalent to `nodeWalkAll`, but only returns nodes that are either
  * ancestors or earlier cousins/siblings in the document.

--- a/dom5.ts
+++ b/dom5.ts
@@ -403,7 +403,12 @@ export function nodeWalkPrior(node: Node, predicate: Predicate): Node|
   return undefined;
 }
 
-export function nodeWalkParent(node: Node, predicate: Predicate): Node|undefined {
+/**
+ * Walk the tree up from the parent of `node`, to its grandparent and so on to
+ * the root of the tree.  Return the first ancestor that matches the given
+ * predicate.
+ */
+export function nodeWalkAncestors(node: Node, predicate: Predicate): Node|undefined {
   const parent = node.parentNode;
   if (!parent) {
     return undefined;
@@ -411,7 +416,7 @@ export function nodeWalkParent(node: Node, predicate: Predicate): Node|undefined
   if (predicate(parent)) {
     return parent;
   }
-  return nodeWalkParent(parent, predicate);
+  return nodeWalkAncestors(parent, predicate);
 }
 
 /**

--- a/test/dom5_test.js
+++ b/test/dom5_test.js
@@ -545,14 +545,19 @@ suite('dom5', function() {
       doc = dom5.parse(docText);
     });
 
-    test('nodeWalkParent', function() {
-      // a -> template -> dom-module -> link -> doc
+    test('nodeWalkAncestors', function() {
+      // doc -> dom-module -> template -> a
       var anchor = doc.childNodes[1].childNodes[1].childNodes[0]
           .childNodes[1].childNodes[0].childNodes[3];
       assert(dom5.predicates.hasTagName('a')(anchor));
       var domModule =
-          dom5.nodeWalkParent(anchor, dom5.predicates.hasTagName('dom-module'));
+          dom5.nodeWalkAncestors(
+              anchor, dom5.predicates.hasTagName('dom-module'));
       assert(domModule);
+      var theLinkIsNotAnAncestor =
+          dom5.nodeWalkAncestors(
+              anchor, dom5.predicates.hasTagName('link'));
+      assert.equal(theLinkIsNotAnAncestor, undefined);
     });
 
     test('nodeWalk', function() {

--- a/test/dom5_test.js
+++ b/test/dom5_test.js
@@ -545,6 +545,16 @@ suite('dom5', function() {
       doc = dom5.parse(docText);
     });
 
+    test('nodeWalkParent', function() {
+      // a -> template -> dom-module -> link -> doc
+      var anchor = doc.childNodes[1].childNodes[1].childNodes[0]
+          .childNodes[1].childNodes[0].childNodes[3];
+      assert(dom5.predicates.hasTagName('a')(anchor));
+      var domModule =
+          dom5.nodeWalkParent(anchor, dom5.predicates.hasTagName('dom-module'));
+      assert(domModule);
+    });
+
     test('nodeWalk', function() {
       // doc -> body -> dom-module -> template -> template.content
       var templateContent = doc.childNodes[1].childNodes[1].childNodes[0]


### PR DESCRIPTION
Recursively walk the lineage until reaching a parent matching the predicate or undefined.

Needed this function because nodeWalkPrior included nodes not in direct lineage and some semantics/behavior depend on direct lineage.