### PR TITLE
Delete parse5 custom_typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Change Log
 
+## Unreleased
+
+- Upgrade to `parse5@^v2.2.22` so that we can take advantage of new types info.
+
 ## [v2.0.0](https://github.com/PolymerLabs/dom5/tree/v2.0.0) (2016-09-23)
-- Upgraded to parse5 v2.2.1
+- Upgraded to `parse5@^v2.2.1`.
 - (*breaking*) Because parse5 2.x correctly handles `<template>` elements,
   the nodeWalk* and query* functions will no longer return results from within
   `<template>`s. Code that relied on this must explicitly walk into template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-- Upgrade to `parse5@^v2.2.22` so that we can take advantage of new types info.
-
 ## [v2.0.0](https://github.com/PolymerLabs/dom5/tree/v2.0.0) (2016-09-23)
 - Upgraded to `parse5@^v2.2.1`.
 - (*breaking*) Because parse5 2.x correctly handles `<template>` elements,

--- a/custom_typings/parse5.d.ts
+++ b/custom_typings/parse5.d.ts
@@ -1,19 +1,7 @@
-import * as parse5 from 'parse5';
+import {ASTNode} from 'parse5';
 
 declare module 'parse5' {
-  interface TreeAdapter {}
-  export class Parser {
-    constructor(treeAdapter?: TreeAdapter, options?: ParserOptions);
-    parse(html: string): ASTNode;
-    parseFragment(html: string): ASTNode;
-  }
-  export class Serializer {
-    constructor();
-    serialize(node: ASTNode): string;
-  }
-  export const TreeAdapters: {
-    default: TreeAdapter;  //
-  };
+  // TODO(fks) 11-01-2016: Remove this once @types/parse5 includes `tagName`
+  // (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/12424)
   export interface ASTNode { tagName?: string; }
-  export interface CommentNode extends ASTNode { data: string; }
 }

--- a/dom5.ts
+++ b/dom5.ts
@@ -14,7 +14,6 @@
 
 /// <reference path="./custom_typings/main.d.ts" />
 import * as cloneObject from 'clone';
-import * as parse5 from 'parse5';
 import {ASTNode as Node} from 'parse5';
 export {ASTNode as Node} from 'parse5';
 
@@ -38,7 +37,8 @@ export function hasAttribute(element: Node, name: string): boolean {
   return getAttributeIndex(element, name) !== -1;
 }
 
-export function hasSpaceSeparatedAttrValue(name: string, value: string): Predicate {
+export function hasSpaceSeparatedAttrValue(
+    name: string, value: string): Predicate {
   return function(element: Node) {
     const attributeValue = getAttribute(element, name);
     if (typeof attributeValue !== 'string') {
@@ -163,7 +163,7 @@ export function normalize(node: Node) {
  */
 export function getTextContent(node: Node): string {
   if (isCommentNode(node)) {
-    return node.data;
+    return node.data || '';
   }
   if (isTextNode(node)) {
     return node.value || '';
@@ -295,7 +295,7 @@ export function isTextNode(node: Node): boolean {
   return node.nodeName === '#text';
 }
 
-export function isCommentNode(node: Node): node is parse5.CommentNode {
+export function isCommentNode(node: Node): boolean {
   return node.nodeName === '#comment';
 }
 
@@ -408,7 +408,8 @@ export function nodeWalkPrior(node: Node, predicate: Predicate): Node|
  * the root of the tree.  Return the first ancestor that matches the given
  * predicate.
  */
-export function nodeWalkAncestors(node: Node, predicate: Predicate): Node|undefined {
+export function nodeWalkAncestors(node: Node, predicate: Predicate): Node|
+    undefined {
   const parent = node.parentNode;
   if (!parent) {
     return undefined;
@@ -473,7 +474,7 @@ function newTextNode(value: string): Node {
   };
 }
 
-function newCommentNode(comment: string): parse5.CommentNode {
+function newCommentNode(comment: string): Node {
   return {
     nodeName: '#comment',
     data: comment,

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   "dependencies": {
     "@types/clone": "^0.1.29",
     "@types/node": "^4.0.30",
-    "@types/parse5": "^0.0.31",
+    "@types/parse5": "^2.2.32",
     "clone": "^1.0.2",
-    "parse5": "^2.2.1"
+    "parse5": "^2.2.2"
   }
 }


### PR DESCRIPTION
Conflicts with the new `@types/parse5` dev dependency, causing build errors for dom5 & consumers.

/cc @justinfagnani @rictic 